### PR TITLE
🤖 ドラッグプレビューのオフセットを保持

### DIFF
--- a/client/components/cell_group.gd
+++ b/client/components/cell_group.gd
@@ -53,6 +53,7 @@ func _has_point(point: Vector2) -> bool:
 func _get_drag_data(at_position: Vector2) -> Variant:
     #print("_get_drag_data", at_position)
     var preview := duplicate() as Control
+    preview.position = -at_position # ドラッグ開始位置との差分を設定してカーソル位置を維持する
     set_drag_preview(preview)
     return { "node": self }
 

--- a/client/scenes/dev/drag_drop/object.gd
+++ b/client/scenes/dev/drag_drop/object.gd
@@ -7,6 +7,7 @@ func _get_drag_data(at_position: Vector2) -> Variant:
     preview.size = self.size
     preview.texture = self.texture
     preview.expand_mode = TextureRect.EXPAND_IGNORE_SIZE
+    preview.position = -at_position # ドラッグ開始位置との差分を設定してカーソル位置を維持する
     set_drag_preview(preview)
     #self.visible = false
     return self


### PR DESCRIPTION
## 概要
- CellGroup のドラッグプレビューをマウスカーソルの相対位置を維持するよう調整
- デバッグ用 Object でも同様にオフセットを設定

## テスト
- `godot --headless --path client -s res://dummy.gd` (godot: command not found)
- `apt-get update` (403 Forbidden により失敗)


------
https://chatgpt.com/codex/tasks/task_b_6899194c7ee8832a9a6dac23e91877d5