### PR TITLE
🤖 セルの当たり判定を矩形に変更

### DIFF
--- a/client/components/cell.tscn
+++ b/client/components/cell.tscn
@@ -2,7 +2,9 @@
 
 [ext_resource type="Script" uid="uid://cqf7bt41oou48" path="res://components/cell.gd" id="1_e0bep"]
 
-[sub_resource type="CircleShape2D" id="CircleShape2D_e0bep"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_e0bep"]
+; セルの大きさに合わせた矩形の当たり判定
+size = Vector2(40, 40)
 
 [node name="Cell" type="Control" node_paths=PackedStringArray("_label", "_bg", "_area")]
 custom_minimum_size = Vector2(40, 40)
@@ -31,7 +33,12 @@ horizontal_alignment = 1
 vertical_alignment = 1
 
 [node name="Area2D" type="Area2D" parent="."]
+; ドロップ判定用の領域
 position = Vector2(20, 20)
+; 不要な衝突層を無効化
+collision_layer = 1
+collision_mask = 1
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource("CircleShape2D_e0bep")
+; セル全体を覆う矩形形状
+shape = SubResource("RectangleShape2D_e0bep")


### PR DESCRIPTION
## 概要
- Area2D の CollisionShape2D を RectangleShape2D に変更
- 矩形サイズを 40x40 に設定し衝突層を整理

## テスト
- `godot --headless --path client --quit` (コマンドが存在せず失敗)
- `apt-get update` (リポジトリが署名されておらず失敗)

------
https://chatgpt.com/codex/tasks/task_b_689af20c5448832aac50a87538c6fb6b