### PR TITLE
🤖 is_holder_active が誤って有効化される問題を修正

### DIFF
--- a/client/components/cell_group.gd
+++ b/client/components/cell_group.gd
@@ -112,9 +112,9 @@ func _on_cell_entered(on: bool) -> void:
         return # ドラッグ中でなければ処理しない
 
     # 直前に重なっていた Cell の色を戻す
+    # is_holder_active を変更すると無効なセルが再び有効になってしまうため、色のみを戻す
     for cell in _prev_overrapping_cells:
         if cell is Cell:
-            cell.is_holder_active = true
             cell.bg_color = Cell.COLOR_DEFAULT
     _prev_overrapping_cells.clear()
 


### PR DESCRIPTION
## 概要
- CellGroup のドラッグ判定で is_holder_active を勝手に有効化しないよう調整

## テスト
- `godot --version` (失敗: command not found)
- `sudo apt-get update` (失敗: 403 でリポジトリにアクセス不可)


------
https://chatgpt.com/codex/tasks/task_b_689cf0d5f8e4832a9a5cc82ed0c17337