### PR TITLE
🤖 Holderセルの色判定をCellに移すリファクタ

### DIFF
--- a/client/components/cell.gd
+++ b/client/components/cell.gd
@@ -78,11 +78,16 @@ func _on_mouse_exited() -> void:
 
 func _on_area_entered(_other_area: Area2D) -> void:
     if is_holder:
-        # 置けるかどうかで色を分ける
-        if is_holder_active:
-            bg_color = COLOR_SUCCESS
-        else:
-            bg_color = COLOR_DANGER
+        var other_cell := _other_area.get_parent()
+        if other_cell is Cell:
+            # 自身が最寄りのホルダー Cell のときのみ色を変更する
+            var nearest_cell := other_cell.get_nearest_overrapping_holder()
+            if nearest_cell == self:
+                # 置けるかどうかで色を分ける
+                if is_holder_active:
+                    bg_color = COLOR_SUCCESS
+                else:
+                    bg_color = COLOR_DANGER
     else:
         cell_entered.emit(true)
 
@@ -93,6 +98,27 @@ func _on_area_exited(_other_area: Area2D) -> void:
         bg_color = COLOR_DEFAULT
     else:
         cell_entered.emit(false)
+
+
+## 自身に重なっているホルダー Cell のうち最寄りを取得する
+## 重なっているホルダー Cell がない場合は null を返す
+func get_nearest_overrapping_holder() -> Cell:
+    var overrapping_areas := area.get_overlapping_areas()
+    if overrapping_areas.is_empty():
+        return null
+
+    var nearest_area := overrapping_areas[0]
+    var nearest_distance := INF
+    for overrapping_area in overrapping_areas:
+        var distance := overrapping_area.global_position.distance_to(global_position)
+        if distance < nearest_distance:
+            nearest_area = overrapping_area
+            nearest_distance = distance
+
+    var nearest_cell := nearest_area.get_parent()
+    if nearest_cell is Cell:
+        return nearest_cell
+    return null
 
 
 func _update_debug() -> void:

--- a/client/components/cell.gd
+++ b/client/components/cell.gd
@@ -8,7 +8,7 @@ signal hovered # (on: bool)
 ## ドラッグを 開始/終了 したとき
 ## 呪文オブジェクト側のみ使用する
 signal dragged # (on: bool)
-## 他の Cell に 入った/外れた とき
+## 他の Cell が 入った/外れた とき
 signal cell_entered # (on: bool)
 
 ## Cell の大きさ (px)
@@ -68,38 +68,6 @@ func _gui_input(event: InputEvent) -> void:
             dragged.emit(event.pressed)
 
 
-func _on_mouse_entered() -> void:
-    hovered.emit(true)
-
-
-func _on_mouse_exited() -> void:
-    hovered.emit(false)
-
-
-func _on_area_entered(_other_area: Area2D) -> void:
-    if is_holder:
-        var other_cell := _other_area.get_parent()
-        if other_cell is Cell:
-            # 自身が最寄りのホルダー Cell のときのみ色を変更する
-            var nearest_cell := other_cell.get_nearest_overrapping_holder()
-            if nearest_cell == self:
-                # 置けるかどうかで色を分ける
-                if is_holder_active:
-                    bg_color = COLOR_SUCCESS
-                else:
-                    bg_color = COLOR_DANGER
-    else:
-        cell_entered.emit(true)
-
-
-func _on_area_exited(_other_area: Area2D) -> void:
-    if is_holder:
-        # 重なりがなくなったら元の色に戻す
-        bg_color = COLOR_DEFAULT
-    else:
-        cell_entered.emit(false)
-
-
 ## 自身に重なっているホルダー Cell のうち最寄りを取得する
 ## 重なっているホルダー Cell がない場合は null を返す
 func get_nearest_overrapping_holder() -> Cell:
@@ -119,6 +87,40 @@ func get_nearest_overrapping_holder() -> Cell:
     if nearest_cell is Cell:
         return nearest_cell
     return null
+
+
+
+func _on_mouse_entered() -> void:
+    hovered.emit(true)
+
+
+func _on_mouse_exited() -> void:
+    hovered.emit(false)
+
+
+func _on_area_entered(_other_area: Area2D) -> void:
+    if is_holder:
+        var other_cell := _other_area.get_parent()
+        if other_cell is Cell:
+            # 自身が最寄りのホルダー Cell のときのみ色を変更する
+            #var nearest_cell := other_cell.get_nearest_overrapping_holder()
+            var nearest_cell = other_cell.get_nearest_overrapping_holder()
+            if nearest_cell is Cell:
+                # 置けるかどうかで色を分ける
+                if is_holder_active:
+                    bg_color = COLOR_SUCCESS
+                else:
+                    bg_color = COLOR_DANGER
+    else:
+        cell_entered.emit(true)
+
+
+func _on_area_exited(_other_area: Area2D) -> void:
+    if is_holder:
+        # 重なりがなくなったら元の色に戻す
+        bg_color = COLOR_DEFAULT
+    else:
+        cell_entered.emit(false)
 
 
 func _update_debug() -> void:

--- a/client/components/cell.gd
+++ b/client/components/cell.gd
@@ -36,6 +36,8 @@ var is_holder_active := false:
     set(v):
         is_holder_active = v
         _update_debug()
+        # 有効状態が変わったら色を初期化する
+        bg_color = COLOR_DEFAULT
 
 ## 呪文の1文字
 var letter := "":
@@ -53,10 +55,9 @@ var bg_color := COLOR_DEFAULT:
 func _ready() -> void:
     mouse_entered.connect(_on_mouse_entered)
     mouse_exited.connect(_on_mouse_exited)
-    # Area の重なり: オブジェクト側のみ
-    if not is_holder:
-        area.area_entered.connect(_on_area_entered)
-        area.area_exited.connect(_on_area_exited)
+    # ホルダー側も重なりを検知するため常に接続する
+    area.area_entered.connect(_on_area_entered)
+    area.area_exited.connect(_on_area_exited)
 
     bg_color = COLOR_DEFAULT
 
@@ -76,11 +77,22 @@ func _on_mouse_exited() -> void:
 
 
 func _on_area_entered(_other_area: Area2D) -> void:
-    cell_entered.emit(true)
+    if is_holder:
+        # 置けるかどうかで色を分ける
+        if is_holder_active:
+            bg_color = COLOR_SUCCESS
+        else:
+            bg_color = COLOR_DANGER
+    else:
+        cell_entered.emit(true)
 
 
 func _on_area_exited(_other_area: Area2D) -> void:
-    cell_entered.emit(false)
+    if is_holder:
+        # 重なりがなくなったら元の色に戻す
+        bg_color = COLOR_DEFAULT
+    else:
+        cell_entered.emit(false)
 
 
 func _update_debug() -> void:

--- a/client/components/cell.gd
+++ b/client/components/cell.gd
@@ -8,7 +8,7 @@ signal hovered # (on: bool)
 ## ドラッグを 開始/終了 したとき
 ## 呪文オブジェクト側のみ使用する
 signal dragged # (on: bool)
-## 他の Cell が 入った/外れた とき
+## 他の Cell に 入った/外れた とき
 signal cell_entered # (on: bool)
 
 ## Cell の大きさ (px)
@@ -68,6 +68,38 @@ func _gui_input(event: InputEvent) -> void:
             dragged.emit(event.pressed)
 
 
+func _on_mouse_entered() -> void:
+    hovered.emit(true)
+
+
+func _on_mouse_exited() -> void:
+    hovered.emit(false)
+
+
+func _on_area_entered(_other_area: Area2D) -> void:
+    if is_holder:
+        var other_cell := _other_area.get_parent()
+        if other_cell is Cell:
+            # 自身が最寄りのホルダー Cell のときのみ色を変更する
+            var nearest_cell := other_cell.get_nearest_overrapping_holder()
+            if nearest_cell == self:
+                # 置けるかどうかで色を分ける
+                if is_holder_active:
+                    bg_color = COLOR_SUCCESS
+                else:
+                    bg_color = COLOR_DANGER
+    else:
+        cell_entered.emit(true)
+
+
+func _on_area_exited(_other_area: Area2D) -> void:
+    if is_holder:
+        # 重なりがなくなったら元の色に戻す
+        bg_color = COLOR_DEFAULT
+    else:
+        cell_entered.emit(false)
+
+
 ## 自身に重なっているホルダー Cell のうち最寄りを取得する
 ## 重なっているホルダー Cell がない場合は null を返す
 func get_nearest_overrapping_holder() -> Cell:
@@ -87,40 +119,6 @@ func get_nearest_overrapping_holder() -> Cell:
     if nearest_cell is Cell:
         return nearest_cell
     return null
-
-
-
-func _on_mouse_entered() -> void:
-    hovered.emit(true)
-
-
-func _on_mouse_exited() -> void:
-    hovered.emit(false)
-
-
-func _on_area_entered(_other_area: Area2D) -> void:
-    if is_holder:
-        var other_cell := _other_area.get_parent()
-        if other_cell is Cell:
-            # 自身が最寄りのホルダー Cell のときのみ色を変更する
-            #var nearest_cell := other_cell.get_nearest_overrapping_holder()
-            var nearest_cell = other_cell.get_nearest_overrapping_holder()
-            if nearest_cell is Cell:
-                # 置けるかどうかで色を分ける
-                if is_holder_active:
-                    bg_color = COLOR_SUCCESS
-                else:
-                    bg_color = COLOR_DANGER
-    else:
-        cell_entered.emit(true)
-
-
-func _on_area_exited(_other_area: Area2D) -> void:
-    if is_holder:
-        # 重なりがなくなったら元の色に戻す
-        bg_color = COLOR_DEFAULT
-    else:
-        cell_entered.emit(false)
 
 
 func _update_debug() -> void:

--- a/client/components/cell_group.gd
+++ b/client/components/cell_group.gd
@@ -98,16 +98,13 @@ func _on_dragged(on: bool) -> void:
             # 置いたホルダーを無効にする
             # TODO: 1文字まで重ねられるようにする
             for overrapping_cell in _prev_overrapping_cells:
-                overrapping_cell.is_holder_active = false
-                overrapping_cell.bg_color = Cell.COLOR_DEFAULT
+                overrapping_cell.is_holder_active = false # 色は Cell 側で自動リセット
         # ドロップできないとき
         else:
             # オブジェクトをドラッグ開始時の座標に戻す
             # TODO: tween で移動する
             global_position = _drag_start_global_position
-            # ホルダーの色を元に戻す
-            for overrapping_cell in _prev_overrapping_cells:
-                overrapping_cell.bg_color = Cell.COLOR_DEFAULT
+            # ホルダーの色リセットは Cell 側で自動化されている
 
 
 func _on_cell_entered(on: bool) -> void:
@@ -118,11 +115,7 @@ func _on_cell_entered(on: bool) -> void:
     if not is_dragging:
         return # ドラッグ中でなければ処理しない
 
-    # 直前に重なっていた Cell の色を戻す
-    # is_holder_active を変更すると無効なセルが再び有効になってしまうため、色のみを戻す
-    for cell in _prev_overrapping_cells:
-        if cell is Cell:
-            cell.bg_color = Cell.COLOR_DEFAULT
+    # 色のリセットは Cell 側で行うためここでは不要
     _prev_overrapping_cells.clear()
 
     # 自身の Cell ごとに重なっているホルダー Area を取得する
@@ -145,9 +138,6 @@ func _on_cell_entered(on: bool) -> void:
             var nearest_cell := nearest_area.get_parent()
             if nearest_cell is Cell:
                 overrapping_cells.push_back(nearest_cell)
-                # ホルダーに置けるかどうかの色を設定する
-                if nearest_cell.is_holder and nearest_cell.is_holder_active:
-                    nearest_cell.bg_color = Cell.COLOR_SUCCESS
     _prev_overrapping_cells = overrapping_cells
     #print("overrapping_cells", overrapping_cells)
 

--- a/client/components/cell_group.gd
+++ b/client/components/cell_group.gd
@@ -118,25 +118,12 @@ func _on_cell_entered(on: bool) -> void:
     # 色のリセットは Cell 側で行うためここでは不要
     _prev_overrapping_cells.clear()
 
-    # 自身の Cell ごとに重なっているホルダー Area を取得する
+    # 自身の Cell ごとに重なっている最寄りのホルダー Cell を取得する
     var overrapping_cells: Array[Cell] = [] # 重なっている Cell
     for cell in cells:
         if cell is Cell:
-            # 自身を構成する Cell が重なっているホルダー Area の中で最寄りを取得する
-            var overrapping_areas := cell.area.get_overlapping_areas() # 重なっている Area[]
-            # 重なっているホルダー Area がない場合: スキップ
-            if overrapping_areas.is_empty():
-                continue
-            var nearest_area := overrapping_areas[0] # 最寄りの Area (現時点では候補)
-            var nearest_distance := INF # 最寄りの Area への距離 (現時点では候補)
-            for overrapping_area in overrapping_areas:
-                var distance := overrapping_area.global_position.distance_to(cell.global_position)
-                if distance < nearest_distance:
-                    nearest_area = overrapping_area
-                    nearest_distance = distance
-            # 最寄りのホルダー Area を元にホルダー Cell を取得する
-            var nearest_cell := nearest_area.get_parent()
-            if nearest_cell is Cell:
+            var nearest_cell := cell.get_nearest_overrapping_holder()
+            if nearest_cell:
                 overrapping_cells.push_back(nearest_cell)
     _prev_overrapping_cells = overrapping_cells
     #print("overrapping_cells", overrapping_cells)


### PR DESCRIPTION
## 概要
- Cell が重なりから自動で色を変更するように整理
- CellGroup のホルダー色制御を撤去

## テスト
- `godot --version`
- `apt-get update` (403 で失敗)

------
https://chatgpt.com/codex/tasks/task_b_689cfdd16b44832ab703ceb9ca7d1d89