### PR TITLE
🤖 ホルダー色がちらつく問題を修正

### DIFF
--- a/client/components/cell_group.gd
+++ b/client/components/cell_group.gd
@@ -98,16 +98,13 @@ func _on_dragged(on: bool) -> void:
             # 置いたホルダーを無効にする
             # TODO: 1文字まで重ねられるようにする
             for overrapping_cell in _prev_overrapping_cells:
-                overrapping_cell.is_holder_active = false
-                overrapping_cell.bg_color = Cell.COLOR_DEFAULT
+                overrapping_cell.is_holder_active = false # 色は Cell 側で自動リセット
         # ドロップできないとき
         else:
             # オブジェクトをドラッグ開始時の座標に戻す
             # TODO: tween で移動する
             global_position = _drag_start_global_position
-            # ホルダーの色を元に戻す
-            for overrapping_cell in _prev_overrapping_cells:
-                overrapping_cell.bg_color = Cell.COLOR_DEFAULT
+            # ホルダーの色リセットは Cell 側で自動化されている
 
 
 func _on_cell_entered(on: bool) -> void:
@@ -118,36 +115,16 @@ func _on_cell_entered(on: bool) -> void:
     if not is_dragging:
         return # ドラッグ中でなければ処理しない
 
-    # 直前に重なっていた Cell の色を戻す
-    # is_holder_active を変更すると無効なセルが再び有効になってしまうため、色のみを戻す
-    for cell in _prev_overrapping_cells:
-        if cell is Cell:
-            cell.bg_color = Cell.COLOR_DEFAULT
+    # 色のリセットは Cell 側で行うためここでは不要
     _prev_overrapping_cells.clear()
 
-    # 自身の Cell ごとに重なっているホルダー Area を取得する
+    # 自身の Cell ごとに重なっている最寄りのホルダー Cell を取得する
     var overrapping_cells: Array[Cell] = [] # 重なっている Cell
     for cell in cells:
         if cell is Cell:
-            # 自身を構成する Cell が重なっているホルダー Area の中で最寄りを取得する
-            var overrapping_areas := cell.area.get_overlapping_areas() # 重なっている Area[]
-            # 重なっているホルダー Area がない場合: スキップ
-            if overrapping_areas.is_empty():
-                continue
-            var nearest_area := overrapping_areas[0] # 最寄りの Area (現時点では候補)
-            var nearest_distance := INF # 最寄りの Area への距離 (現時点では候補)
-            for overrapping_area in overrapping_areas:
-                var distance := overrapping_area.global_position.distance_to(cell.global_position)
-                if distance < nearest_distance:
-                    nearest_area = overrapping_area
-                    nearest_distance = distance
-            # 最寄りのホルダー Area を元にホルダー Cell を取得する
-            var nearest_cell := nearest_area.get_parent()
-            if nearest_cell is Cell:
+            var nearest_cell := cell.get_nearest_overrapping_holder()
+            if nearest_cell:
                 overrapping_cells.push_back(nearest_cell)
-                # ホルダーに置けるかどうかの色を設定する
-                if nearest_cell.is_holder and nearest_cell.is_holder_active:
-                    nearest_cell.bg_color = Cell.COLOR_SUCCESS
     _prev_overrapping_cells = overrapping_cells
     #print("overrapping_cells", overrapping_cells)
 


### PR DESCRIPTION
## 概要
- ホルダーが重なっている Cell を走査して最寄り判定を再計算し色を更新
- 重なりが解除されたときも状態に応じて色を保持するように修正

## テスト
- `godot --version` (コマンド未検出)

------
https://chatgpt.com/codex/tasks/task_b_689cfdd16b44832ab703ceb9ca7d1d89